### PR TITLE
Very minor synopsis tweak

### DIFF
--- a/lib/MooseX/LazyRequire.pm
+++ b/lib/MooseX/LazyRequire.pm
@@ -28,7 +28,7 @@ use namespace::autoclean;
 
     Foo->new(foo => 42); # succeeds, foo and bar will be 42
     Foo->new(bar => 42); # succeeds, bar will be 42
-    Foo->new;            # fails, neither foo nor bare were given
+    Foo->new;            # fails in _build_bar, neither foo nor bar were given
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
MooseX::LazyRequire was recommended to me on #moose, but I failed to understand how it worked because I read the synopsis too hastily. (I think I thought the second attribute _also_ had a lazy requirement, which clearly would never work as you'd end up with an endless loop, but I never got to think myself to that point.) I think a clearer explanation of _why_ the constructor fails would possibly help others in similar situations.

Even if it doesn't, I don't think there would be any harm.

Much more trivially, but also far more clearly wrong, there was a typo which I've also corrected ;-) .
